### PR TITLE
Calculate confusion matrix values

### DIFF
--- a/new.py
+++ b/new.py
@@ -56,7 +56,7 @@ def find_best_threshold(y_true, y_scores):
 
 def compute_sensitivity_specificity(y_true, y_pred):
     """Compute sensitivity and specificity from binary predictions."""
-    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
+    tn, fp, fn, tp = confusion_matrix(y_true, y_pred, labels=[0, 1]).ravel()
     sensitivity = tp / (tp + fn) if (tp + fn) > 0 else np.nan
     specificity = tn / (tn + fp) if (tn + fp) > 0 else np.nan
     return sensitivity, specificity

--- a/old.py
+++ b/old.py
@@ -14,7 +14,7 @@ def compute_sensitivity_specificity(y_true, y_pred):
     Compute sensitivity (true positive rate) and specificity (true negative rate)
     from binary predictions.
     """
-    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
+    tn, fp, fn, tp = confusion_matrix(y_true, y_pred, labels=[0, 1]).ravel()
     sensitivity = tp / (tp + fn) if (tp + fn) > 0 else np.nan
     specificity = tn / (tn + fp) if (tn + fp) > 0 else np.nan
     return sensitivity, specificity


### PR DESCRIPTION
Fix `ValueError` in `compute_sensitivity_specificity` by forcing `confusion_matrix` to return a 2x2 matrix.

The `confusion_matrix().ravel()` call previously failed when `y_true` and `y_pred` contained only one class, leading to a `ValueError: not enough values to unpack (expected 4, got 1)`. By passing `labels=[0, 1]`, the confusion matrix is guaranteed to be 2x2, ensuring `ravel()` always produces the expected four values (tn, fp, fn, tp).

---
<a href="https://cursor.com/background-agent?bcId=bc-e234b2e5-dba3-48a6-b6fd-5a16dea7bf97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e234b2e5-dba3-48a6-b6fd-5a16dea7bf97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

