### PR TITLE
Modify tableone generation by gender and ICD

### DIFF
--- a/cox.py
+++ b/cox.py
@@ -206,6 +206,13 @@ def generate_tableone_by_sex_icd(
     df_local["Group"] = np.select(conditions, choices, default=np.nan)
 
     group_order = ["Male-ICD", "Male-No ICD", "Female-ICD", "Female-No ICD"]
+    # Ensure ordered categorical for predictable column order in TableOne
+    try:
+        df_local["Group"] = pd.Categorical(
+            df_local["Group"], categories=group_order, ordered=True
+        )
+    except Exception:
+        pass
 
     # Use all columns except identifiers and helper columns
     exclude_cols = {"MRN", "Group"}
@@ -242,6 +249,9 @@ def generate_tableone_by_sex_icd(
                 groupby="Group",
                 groupby_order=group_order,
                 pval=True,
+                overall=True,
+                missing=True,
+                label_suffix=True,
             )
             print("==== TableOne (Sex x ICD) ====")
             print(tab1)


### PR DESCRIPTION
Update TableOne generation to include Overall/Missing columns and group by four Sex×ICD categories.

---
<a href="https://cursor.com/background-agent?bcId=bc-2018167c-8df5-4190-8a2d-dc73f9177693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2018167c-8df5-4190-8a2d-dc73f9177693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

