### PR TITLE
Move plot legend to the right

### DIFF
--- a/plot.py
+++ b/plot.py
@@ -89,17 +89,18 @@ def plot_metrics_with_ci_groups(df):
         ax.set_title(metric_label)
         ax.grid(axis="y", linestyle="--", alpha=0.3)
 
-    # Shared legend above plots (models)
+    # Shared legend on the right (models)
     handles, labels = axs[0].get_legend_handles_labels()
     fig.legend(
         handles,
         labels,
-        loc="upper center",
-        ncol=len(labels),
-        bbox_to_anchor=(0.5, 1.05),
+        loc="center left",
+        bbox_to_anchor=(1.02, 0.5),
+        borderaxespad=0.0,
+        ncol=1,
     )
 
-    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    plt.tight_layout(rect=[0, 0, 0.85, 1])
     plt.show()
 
 
@@ -165,12 +166,13 @@ def plot_single_metric_rows_as_models(df, metric_title="Metric"):
     fig.legend(
         handles,
         labels,
-        loc="upper center",
-        ncol=min(len(labels), 4),
-        bbox_to_anchor=(0.5, 1.05),
+        loc="center left",
+        bbox_to_anchor=(1.02, 0.5),
+        borderaxespad=0.0,
+        ncol=1,
     )
 
-    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    plt.tight_layout(rect=[0, 0, 0.85, 1])
     plt.show()
 
 


### PR DESCRIPTION
Move plot legends to the right side of the figures in `plot.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-40ed268c-387d-4c4b-b4d6-939e7bd9a7c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40ed268c-387d-4c4b-b4d6-939e7bd9a7c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

